### PR TITLE
Missing dashes before dapr-http-port

### DIFF
--- a/demo1/Readme.md
+++ b/demo1/Readme.md
@@ -32,7 +32,7 @@ Run the following commands to upgrade pip and install FastAI
 
 ### Running the application using the Dapr CLI
 ```bash
-dapr run --app-id api --app-port 8000 dapr-http-port 3500 python main.py
+dapr run --app-id api --app-port 8000 --dapr-http-port 3500 python main.py
 ```
 
 ### Making API requests


### PR DESCRIPTION
The command for running the application using the Dapr CLI is not formatted correctly. The argument dapr-http-port is missing two dashes. Without these dashes the dapr cli try to run an executable file called dapr-http-port which is not the intention of this command. Adding two dashes before the argument resolve the issue.